### PR TITLE
chore: update screenshot image sizes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ align="center">](https://belberi.com/anitail/?fbclid=PAY2xjawJP5dlleHRuA2FlbQIxM
 
 
 <img
-src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/featureGraphic.png" width="91%" />
+src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/featureGraphic.png" width="70%" />
 </div>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ align="center">](https://belberi.com/anitail/?fbclid=PAY2xjawJP5dlleHRuA2FlbQIxM
 <div align="center">
 <h1>Screenshots</h1>
 
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="40%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="40%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="40%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="40%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="43%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="43%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="43%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="43%" />
 
 
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ align="center">](https://belberi.com/anitail/?fbclid=PAY2xjawJP5dlleHRuA2FlbQIxM
 <div align="center">
 <h1>Screenshots</h1>
 
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="20%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="20%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="20%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="20%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="50%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="50%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="50%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="50%" />
 
 
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ align="center">](https://belberi.com/anitail/?fbclid=PAY2xjawJP5dlleHRuA2FlbQIxM
 <div align="center">
 <h1>Screenshots</h1>
 
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="50%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="50%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="50%" />
-  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="50%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img1.jpg" width="40%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img2.jpg" width="40%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img3.jpg" width="40%" />
+  <img src="https://github.com/Animetailapp/AniTail/blob/master/fastlane/metadata/android/en-US/images/screenshots/img4.jpg" width="40%" />
 
 
 


### PR DESCRIPTION
This pull request updates the image display sizes in the `README.md` file to improve visual presentation.

Changes to image sizes:

* Updated the width of individual screenshots from `20%` to `43%` to make them larger and more visually prominent. (`README.md`, [README.mdL63-R72](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R72))
* Reduced the width of the feature graphic from `91%` to `70%` to better balance its size relative to the screenshots. (`README.md`, [README.mdL63-R72](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R72))