### PR TITLE
feat(player): enhance player UI with dynamic now playing header and s…

### DIFF
--- a/app/src/main/kotlin/com/anitail/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/anitail/music/ui/player/Player.kt
@@ -598,19 +598,25 @@ fun BottomSheetPlayer(
                                 .clip(shareShape)
                                 .background(textButtonColor)
                                 .clickable {
-                                    val intent = Intent().apply {
-                                        action = Intent.ACTION_SEND
-                                        type = "text/plain"
-                                        putExtra(
-                                            Intent.EXTRA_TEXT,
-                                            "https://music.youtube.com/watch?v=${mediaMetadata.id}"
+                                    menuState.show {
+                                        PlayerMenu(
+                                            mediaMetadata = mediaMetadata,
+                                            navController = navController,
+                                            playerBottomSheetState = state,
+                                            onShowDetailsDialog = {
+                                                mediaMetadata.id.let {
+                                                    bottomSheetPageState.show {
+                                                        ShowMediaInfo(it)
+                                                    }
+                                                }
+                                            },
+                                            onDismiss = menuState::dismiss,
                                         )
                                     }
-                                    context.startActivity(Intent.createChooser(intent, null))
                                 }
                         ) {
                             Image(
-                                painter = painterResource(R.drawable.share),
+                                painter = painterResource(R.drawable.more_vert),
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(iconButtonColor),
                                 modifier = Modifier
@@ -1101,16 +1107,97 @@ fun BottomSheetPlayer(
                             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
                             .padding(bottom = queueSheetState.collapsedBound + 48.dp),
                 ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
+                    Column(
                         modifier = Modifier.weight(1f),
                     ) {
-                        val screenWidth = LocalConfiguration.current.screenWidthDp
-                        val thumbnailSize = (screenWidth * 0.4).dp
-                        Thumbnail(
-                            sliderPositionProvider = { sliderPosition },
-                            modifier = Modifier.size(thumbnailSize)
-                        )
+                        // Now Playing Header for Landscape
+                        Row(
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = PlayerHorizontalPadding)
+                                .padding(top = 36.dp, bottom = 12.dp)
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.now_playing),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = TextBackgroundColor.copy(alpha = 0.8f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+
+                                Spacer(Modifier.height(3.dp))
+
+                                // Show queue name dynamically based on current playing context
+                                val queueTitle = when {
+                                    mediaMetadata?.album != null -> mediaMetadata!!.album!!.title
+                                    automix.isNotEmpty() -> "Automix"
+                                    currentSong?.song?.title != null -> stringResource(R.string.queue_all_songs)
+                                    else -> "Unknown"
+                                }
+                                Text(
+                                    text = queueTitle,
+                                    style = MaterialTheme.typography.headlineMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    color = TextBackgroundColor,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.basicMarquee()
+                                )
+                            }
+
+                            if (useNewPlayerDesign) {
+
+                                Box(
+                                    modifier = Modifier
+                                        .size(38.dp)
+                                        .clip(RoundedCornerShape(19.dp))
+                                        .background(textButtonColor.copy(alpha = 0.8f))
+                                        .clickable {
+                                            val intent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                type = "text/plain"
+                                                putExtra(
+                                                    Intent.EXTRA_TEXT,
+                                                    "https://music.youtube.com/watch?v=${mediaMetadata?.id}"
+                                                )
+                                            }
+                                            context.startActivity(
+                                                Intent.createChooser(
+                                                    intent,
+                                                    null
+                                                )
+                                            )
+                                        }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.share),
+                                        contentDescription = "Share",
+                                        tint = iconButtonColor,
+                                        modifier = Modifier
+                                            .align(Alignment.Center)
+                                            .size(21.dp)
+                                    )
+                                }
+                            }
+                        }
+
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            val screenWidth = LocalConfiguration.current.screenWidthDp
+                            val thumbnailSize = (screenWidth * 0.4).dp
+                            Thumbnail(
+                                sliderPositionProvider = { sliderPosition },
+                                modifier = Modifier.size(thumbnailSize)
+                            )
+                        }
                     }
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1138,6 +1225,77 @@ fun BottomSheetPlayer(
                             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
                             .padding(bottom = queueSheetState.collapsedBound),
                 ) {
+                    // Now Playing Header
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = PlayerHorizontalPadding)
+                            .padding(top = 40.dp, bottom = 16.dp)
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.now_playing),
+                                style = MaterialTheme.typography.titleMedium,
+                                color = TextBackgroundColor.copy(alpha = 0.8f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+
+                            Spacer(Modifier.height(4.dp))
+
+                            // Show queue name dynamically based on current playing context
+                            val queueTitle = when {
+                                mediaMetadata?.album != null -> mediaMetadata!!.album!!.title
+                                automix.isNotEmpty() -> "Automix"
+                                currentSong?.song?.title != null -> stringResource(R.string.queue_all_songs)
+                                else -> "Unknown"
+                            }
+                            Text(
+                                text = queueTitle,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = TextBackgroundColor,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.basicMarquee()
+                            )
+                        }
+                        if (useNewPlayerDesign) {
+                            // Share button on the right
+                            Box(
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .clip(RoundedCornerShape(20.dp))
+                                    .background(textButtonColor.copy(alpha = 0.8f))
+                                    .clickable {
+                                        val intent = Intent().apply {
+                                            action = Intent.ACTION_SEND
+                                            type = "text/plain"
+                                            putExtra(
+                                                Intent.EXTRA_TEXT,
+                                                "https://music.youtube.com/watch?v=${mediaMetadata?.id}"
+                                            )
+                                        }
+                                        context.startActivity(Intent.createChooser(intent, null))
+                                    }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.share),
+                                    contentDescription = "Share",
+                                    tint = iconButtonColor,
+                                    modifier = Modifier
+                                        .align(Alignment.Center)
+                                        .size(22.dp)
+                                )
+                            }
+                        }
+                    }
+                    
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier.weight(1f),

--- a/app/src/main/kotlin/com/anitail/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/anitail/music/ui/player/Queue.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -143,7 +142,6 @@ fun Queue(
     val repeatMode by playerConnection.repeatMode.collectAsState()
 
     val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
     val selectedSongs: MutableList<MediaMetadata> = mutableStateListOf()
     val selectedItems: MutableList<Timeline.Window> = mutableStateListOf()
@@ -196,7 +194,7 @@ fun Queue(
             if (useNewPlayerDesign) {
                 // New design
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -211,173 +209,144 @@ fun Queue(
                     val iconSize = 24.dp
                     val borderColor = TextBackgroundColor.copy(alpha = 0.35f)
 
-                    Box(
-                        modifier = Modifier
-                            .size(buttonSize)
-                            .clip(
-                                RoundedCornerShape(
-                                    topStart = 50.dp,
-                                    bottomStart = 50.dp,
-                                    topEnd = 10.dp,
-                                    bottomEnd = 10.dp
-                                )
-                            )
-                            .border(
-                                1.dp,
-                                borderColor,
-                                RoundedCornerShape(
-                                    topStart = 50.dp,
-                                    bottomStart = 50.dp,
-                                    topEnd = 10.dp,
-                                    bottomEnd = 10.dp
-                                )
-                            )
-                            .clickable { state.expandSoft() },
-                        contentAlignment = Alignment.Center
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.queue_music),
-                            contentDescription = null,
-                            modifier = Modifier.size(iconSize),
-                            tint = TextBackgroundColor
-                        )
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .size(buttonSize)
-                            .clip(RoundedCornerShape(10.dp))
-                            .border(1.dp, borderColor, RoundedCornerShape(10.dp))
-                            .clickable {
-                                if (sleepTimerEnabled) {
-                                    playerConnection.service.sleepTimer.clear()
-                                } else {
-                                    showSleepTimerDialog = true
-                                }
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        AnimatedContent(
-                            label = "sleepTimer",
-                            targetState = sleepTimerEnabled,
-                        ) { enabled ->
-                            if (enabled) {
-                                Text(
-                                    text = makeTimeString(sleepTimerTimeLeft),
-                                    color = TextBackgroundColor,
-                                    fontSize = 10.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .basicMarquee()
+                        Box(
+                            modifier = Modifier
+                                .size(buttonSize)
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = 50.dp,
+                                        bottomStart = 50.dp,
+                                        topEnd = 10.dp,
+                                        bottomEnd = 10.dp
+                                    )
                                 )
-                            } else {
-                                Icon(
-                                    painter = painterResource(id = R.drawable.bedtime),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(iconSize),
-                                    tint = TextBackgroundColor
+                                .border(
+                                    1.dp,
+                                    borderColor,
+                                    RoundedCornerShape(
+                                        topStart = 50.dp,
+                                        bottomStart = 50.dp,
+                                        topEnd = 10.dp,
+                                        bottomEnd = 10.dp
+                                    )
                                 )
-                            }
+                                .clickable { state.expandSoft() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.queue_music),
+                                contentDescription = null,
+                                modifier = Modifier.size(iconSize),
+                                tint = TextBackgroundColor
+                            )
                         }
-                    }
 
-                    Box(
-                        modifier = Modifier
-                            .size(buttonSize)
-                            .clip(RoundedCornerShape(10.dp))
-                            .border(1.dp, borderColor, RoundedCornerShape(10.dp))
-                            .clickable {
-                                showLyrics = !showLyrics
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.lyrics),
-                            contentDescription = null,
+                        Box(
                             modifier = Modifier
-                                .size(iconSize)
-                                .alpha(if (showLyrics) 1f else 0.5f),
-                            tint = TextBackgroundColor
-                        )
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .size(buttonSize)
-                            .clip(
-                                RoundedCornerShape(
-                                    topStart = 10.dp,
-                                    bottomStart = 10.dp,
-                                    topEnd = 50.dp,
-                                    bottomEnd = 50.dp
-                                )
-                            )
-                            .border(
-                                1.dp,
-                                borderColor,
-                                RoundedCornerShape(
-                                    topStart = 10.dp,
-                                    bottomStart = 10.dp,
-                                    topEnd = 50.dp,
-                                    bottomEnd = 50.dp
-                                )
-                            )
-                            .clickable {
-                                playerConnection.player.toggleRepeatMode()
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                id = when (repeatMode) {
-                                    Player.REPEAT_MODE_OFF, Player.REPEAT_MODE_ALL -> R.drawable.repeat
-                                    Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
-                                    else -> R.drawable.repeat
-                                }
-                            ),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(iconSize)
-                                .alpha(if (repeatMode == Player.REPEAT_MODE_OFF) 0.5f else 1f),
-                            tint = TextBackgroundColor
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    Box(
-                        modifier = Modifier
-                            .size(buttonSize)
-                            .clip(CircleShape)
-                            .background(textButtonColor)
-                            .clickable {
-                                menuState.show {
-                                    PlayerMenu(
-                                        mediaMetadata = mediaMetadata,
-                                        navController = navController,
-                                        playerBottomSheetState = state,
-                                        onShowDetailsDialog = {
-                                            mediaMetadata?.id?.let {
-                                                bottomSheetPageState.show {
-                                                    ShowMediaInfo(it)
-                                                }
-                                            }
-                                        },
-                                        onDismiss = menuState::dismiss
+                                .size(buttonSize)
+                                .clip(RoundedCornerShape(10.dp))
+                                .border(1.dp, borderColor, RoundedCornerShape(10.dp))
+                                .clickable {
+                                    if (sleepTimerEnabled) {
+                                        playerConnection.service.sleepTimer.clear()
+                                    } else {
+                                        showSleepTimerDialog = true
+                                    }
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            AnimatedContent(
+                                label = "sleepTimer",
+                                targetState = sleepTimerEnabled,
+                            ) { enabled ->
+                                if (enabled) {
+                                    Text(
+                                        text = makeTimeString(sleepTimerTimeLeft),
+                                        color = TextBackgroundColor,
+                                        fontSize = 10.sp,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .basicMarquee()
+                                    )
+                                } else {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.bedtime),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(iconSize),
+                                        tint = TextBackgroundColor
                                     )
                                 }
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.more_vert),
-                            contentDescription = null,
-                            modifier = Modifier.size(iconSize),
-                            tint = iconButtonColor
-                        )
+                            }
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .size(buttonSize)
+                                .clip(RoundedCornerShape(10.dp))
+                                .border(1.dp, borderColor, RoundedCornerShape(10.dp))
+                                .clickable {
+                                    showLyrics = !showLyrics
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.lyrics),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(iconSize)
+                                    .alpha(if (showLyrics) 1f else 0.5f),
+                                tint = TextBackgroundColor
+                            )
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .size(buttonSize)
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = 10.dp,
+                                        bottomStart = 10.dp,
+                                        topEnd = 50.dp,
+                                        bottomEnd = 50.dp
+                                    )
+                                )
+                                .border(
+                                    1.dp,
+                                    borderColor,
+                                    RoundedCornerShape(
+                                        topStart = 10.dp,
+                                        bottomStart = 10.dp,
+                                        topEnd = 50.dp,
+                                        bottomEnd = 50.dp
+                                    )
+                                )
+                                .clickable {
+                                    playerConnection.player.toggleRepeatMode()
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                painter = painterResource(
+                                    id = when (repeatMode) {
+                                        Player.REPEAT_MODE_OFF, Player.REPEAT_MODE_ALL -> R.drawable.repeat
+                                        Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
+                                        else -> R.drawable.repeat
+                                    }
+                                ),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(iconSize)
+                                    .alpha(if (repeatMode == Player.REPEAT_MODE_OFF) 0.5f else 1f),
+                                tint = TextBackgroundColor
+                            )
+                        }
                     }
                 }
             } else {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -239,6 +239,7 @@
     <string name="undo">Deshacer</string>
 
     <!-- Reproductor -->
+    <string name="now_playing">Reproduciendo ahora</string>
     <string name="lyrics_not_found">Letra no encontrada</string>
     <string name="sleep_timer">Temporizador</string>
     <string name="end_of_song">Fin de la canción</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="undo">Undo</string>
 
     <!-- Player -->
+    <string name="now_playing">Now playing</string>
     <string name="lyrics_not_found">Lyrics not found</string>
     <string name="sleep_timer">Sleep timer</string>
     <string name="end_of_song">End of song</string>


### PR DESCRIPTION
This pull request introduces significant enhancements to the player UI in both portrait and landscape modes, refines the queue design, and adds new localized strings. The most important changes include the addition of dynamic headers for the "Now Playing" section, the replacement of the share button with a menu button in the player, and adjustments to the queue layout for better alignment and spacing.

### Player UI Enhancements:

* Added dynamic "Now Playing" headers in both landscape and portrait modes, displaying the current queue name based on the playing context (`mediaMetadata.album`, `automix`, or `currentSong.song.title`). [[1]](diffhunk://#diff-00f1edad923d7b491bc4c26870ac31f16e099beb40b3996fcdfad7e2e724694dR1110-R1189) [[2]](diffhunk://#diff-00f1edad923d7b491bc4c26870ac31f16e099beb40b3996fcdfad7e2e724694dR1228-R1298)
* Replaced the share button with a menu button in the player, allowing users to access additional options via `PlayerMenu`, including showing media details.

### Queue Design Refinements:

* Removed the `CircleShape` import and adjusted the queue layout by centering elements and refining spacing. [[1]](diffhunk://#diff-c5aff82000c682c70df8fa87798a565a253ba92e6d972f79ceb1822dd96b6688L40) [[2]](diffhunk://#diff-c5aff82000c682c70df8fa87798a565a253ba92e6d972f79ceb1822dd96b6688L199-R197)
* Simplified the queue's action buttons, removing the menu button and its associated functionality.

### Localization Updates:

* Added new localized strings for "Now Playing" in both English (`strings.xml`) and Spanish (`strings.xml`). [[1]](diffhunk://#diff-8c6b298e44d13c3fb1a2b68937365e5e0746ab568b88bb6dc7a44936f8c653acR242) [[2]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R255)